### PR TITLE
Fix compilation errors on present versions of GCC

### DIFF
--- a/libcpp/macro.c
+++ b/libcpp/macro.c
@@ -1573,7 +1573,7 @@ create_iso_definition (cpp_reader *pfile, cpp_macro *macro)
 	     function-like macros, but not at the end.  */
 	  if (following_paste_op)
 	    {
-	      cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
+	      cpp_error (pfile, CPP_DL_ERROR, "%s", paste_op_error_msg);
 	      return false;
 	    }
 	  break;
@@ -1586,7 +1586,7 @@ create_iso_definition (cpp_reader *pfile, cpp_macro *macro)
 	     function-like macros, but not at the beginning.  */
 	  if (macro->count == 1)
 	    {
-	      cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
+	      cpp_error (pfile, CPP_DL_ERROR, "%s", paste_op_error_msg);
 	      return false;
 	    }
 

--- a/src/nesc-generate.c
+++ b/src/nesc-generate.c
@@ -190,7 +190,7 @@ static bool prt_arguments(declaration parms, bool first, bool rename)
       if (rename || !vd->ddecl->name)
 	output("arg_%p", vd->ddecl);
       else
-	output((char *)vd->ddecl->name);
+	output("%s", (char *)vd->ddecl->name);
     }
   return first;
 }


### PR DESCRIPTION
Present versions of GCC checks whether format strings are passed to places where format strings are expected.
And thus resulting in errors like these:
```
macro.c: In function ‘create_iso_definition’:
macro.c:1576:8: error: format not a string literal and no format arguments [-Werror=format-security]
 1576 |        cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
      |        ^~~~~~~~~
macro.c:1589:8: error: format not a string literal and no format arguments [-Werror=format-security]
 1589 |        cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
      |        ^~~~~~~~~
```

This PR fixes format-strings-related compilation errors.